### PR TITLE
add additonal check for detecting if bot is in an existing conversation

### DIFF
--- a/extensions/server_test.go
+++ b/extensions/server_test.go
@@ -196,7 +196,7 @@ func TestExtension_ListenerREST_ExecuteExtension(t *testing.T) {
 				r: httptest.NewRequest("POST", commandPath, bytes.NewBuffer([]byte(`{"extension": "any", "fsm": {"state": 0, "slots": {}}}`))),
 			},
 			want: &extensions.ExecuteExtensionResponse{
-				FSM: &fsm.FSM{State: 0, Slots: fsm.NewFSM().Slots},
+				FSM: &fsm.FSM{State: fsm.StateInitial, Slots: fsm.NewFSM().Slots},
 				Answers: []query.Answer{{
 					Text:  "Hello Universe",
 					Image: "https://i.imgur.com/pPdjh6x.jpg",
@@ -210,7 +210,7 @@ func TestExtension_ListenerREST_ExecuteExtension(t *testing.T) {
 				r: setBearerToken(httptest.NewRequest("POST", commandPath, bytes.NewBuffer([]byte(`{"extension": "any", "fsm": {"state": 0, "slots": {}}}`))), "my-test-token"),
 			},
 			want: &extensions.ExecuteExtensionResponse{
-				FSM: &fsm.FSM{State: 0, Slots: fsm.NewFSM().Slots},
+				FSM: &fsm.FSM{State: fsm.StateInitial, Slots: fsm.NewFSM().Slots},
 				Answers: []query.Answer{{
 					Text:  "Hello Universe",
 					Image: "https://i.imgur.com/pPdjh6x.jpg",
@@ -289,7 +289,7 @@ func TestExtensionRPCServer(t *testing.T) {
 	req := extensions.ExecuteExtensionRequest{
 		Extension: "any",
 		FSM: &fsm.FSM{
-			State: 0,
+			State: fsm.StateInitial,
 			Slots: make(map[string]string),
 		},
 	}

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -7,6 +7,15 @@ import (
 	"github.com/jaimeteb/chatto/query"
 )
 
+const (
+	// StateInitial is the first state the FSM enters upon
+	// initialization of a new conversation and when ending
+	// an existing conversation
+	StateInitial = 0
+	// StateAny allows transitioning from any state
+	StateAny = -1
+)
+
 // Transition lists the transitions available for the FSM
 // Describes the states of the transition
 // (from one state into another) if the functions command
@@ -53,7 +62,7 @@ func NewStateTable(states []string) StateTable {
 		stateTable[state] = id
 	}
 
-	stateTable["any"] = -1 // Add state "any"
+	stateTable["any"] = StateAny
 
 	return stateTable
 }
@@ -174,7 +183,7 @@ type FSM struct {
 
 // NewFSM instantiates a new FSM
 func NewFSM() *FSM {
-	return &FSM{State: 0, Slots: make(map[string]string)}
+	return &FSM{State: StateInitial, Slots: make(map[string]string)}
 }
 
 // ExecuteCmd executes a state transition in the FSM based on
@@ -202,7 +211,7 @@ func (m *FSM) ExecuteCmd(command, classifiedText string, fsmDomain *Domain) (ans
 // SelectStateTransition based on the command provided
 func (m *FSM) SelectStateTransition(command string, fsmDomain *Domain) (CmdStateTuple, TransitionFunc) {
 	// fromAnyState means we can transition from any state
-	fromAnyState := CmdStateTuple{command, -1}
+	fromAnyState := CmdStateTuple{command, StateAny}
 
 	// cmdAnyState transition between any two states
 	cmdAnyState := CmdStateTuple{"any", m.State}

--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -132,7 +132,7 @@ func TestFSM_ExecuteCmd(t *testing.T) {
 		{
 			name: "invalid command should be unknown",
 			fields: fields{
-				State: 0,
+				State: fsm.StateInitial,
 				Slots: make(map[string]string),
 			},
 			args: args{
@@ -142,14 +142,14 @@ func TestFSM_ExecuteCmd(t *testing.T) {
 			},
 			wantAnswers:   nil,
 			wantExtension: "",
-			wantState:     0,
+			wantState:     fsm.StateInitial,
 			wantSlots:     map[string]string{},
 			wantErr:       true,
 		},
 		{
 			name: "empty command should be unsure",
 			fields: fields{
-				State: 0,
+				State: fsm.StateInitial,
 				Slots: make(map[string]string),
 			},
 			args: args{
@@ -159,14 +159,14 @@ func TestFSM_ExecuteCmd(t *testing.T) {
 			},
 			wantAnswers:   nil,
 			wantExtension: "",
-			wantState:     0,
+			wantState:     fsm.StateInitial,
 			wantSlots:     map[string]string{},
 			wantErr:       true,
 		},
 		{
 			name: "hello command should run hey_friend from any state",
 			fields: fields{
-				State: 0,
+				State: fsm.StateInitial,
 				Slots: make(map[string]string),
 			},
 			args: args{
@@ -195,14 +195,14 @@ func TestFSM_ExecuteCmd(t *testing.T) {
 			},
 			wantAnswers:   nil,
 			wantExtension: "search_pokemon",
-			wantState:     0,
+			wantState:     fsm.StateInitial,
 			wantSlots:     map[string]string{"pokemon": "pikachu"},
 			wantErr:       false,
 		},
 		{
 			name: "turn_on command should turn on",
 			fields: fields{
-				State: 0,
+				State: fsm.StateInitial,
 				Slots: make(map[string]string),
 			},
 			args: args{
@@ -238,7 +238,7 @@ func TestFSM_ExecuteCmd(t *testing.T) {
 				},
 			},
 			wantExtension: "",
-			wantState:     0,
+			wantState:     fsm.StateInitial,
 			wantSlots:     map[string]string{"off": "turn it off"},
 			wantErr:       false,
 		},

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -40,6 +40,14 @@ func (b *Bot) Answer(receiveMsg *messages.Receive) ([]query.Answer, error) {
 
 	previousState := machine.State
 
+	// Set existing conversation to false if in initial state.
+	// This tells the bot that it is having a new conversation
+	if initialID, ok := b.Domain.StateTable["initial"]; ok {
+		if initialID == machine.State {
+			isExistingConversation = false
+		}
+	}
+
 	answers, ext, err := machine.ExecuteCmd(cmd, receiveMsg.Question.Text, b.Domain)
 	if err != nil {
 		switch e := err.(type) {

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -40,12 +40,10 @@ func (b *Bot) Answer(receiveMsg *messages.Receive) ([]query.Answer, error) {
 
 	previousState := machine.State
 
-	// Set existing conversation to false if in initial state.
-	// This tells the bot that it is having a new conversation
-	if initialID, ok := b.Domain.StateTable["initial"]; ok {
-		if initialID == machine.State {
-			isExistingConversation = false
-		}
+	// Set existing conversation to false if in the initial state
+	// because initial state means this is a new conversation
+	if machine.State == fsm.StateInitial {
+		isExistingConversation = false
 	}
 
 	answers, ext, err := machine.ExecuteCmd(cmd, receiveMsg.Question.Text, b.Domain)

--- a/internal/fsm/store_test.go
+++ b/internal/fsm/store_test.go
@@ -33,11 +33,11 @@ func TestCacheStore(t *testing.T) {
 	machines.Set(
 		"foo",
 		&fsm.FSM{
-			State: 0,
+			State: fsm.StateInitial,
 			Slots: make(map[string]string),
 		},
 	)
-	if resp2 := machines.Get("foo"); resp2.State != 0 {
+	if resp2 := machines.Get("foo"); resp2.State != fsm.StateInitial {
 		t.Errorf("incorrect, got: %v, want: %v.", resp2, "0")
 	}
 
@@ -80,11 +80,11 @@ func TestRedisStore(t *testing.T) {
 	machines.Set(
 		"foo",
 		&fsm.FSM{
-			State: 0,
+			State: fsm.StateInitial,
 			Slots: make(map[string]string),
 		},
 	)
-	if resp2 := machines.Get("foo"); resp2.State != 0 {
+	if resp2 := machines.Get("foo"); resp2.State != fsm.StateInitial {
 		t.Errorf("incorrect, got: %v, want: %v.", resp2, "0")
 	}
 


### PR DESCRIPTION
This check sets `isExistingConversation` to `false` if the current state is set to `initial`. This furthers the distinction between a `new` and `existing` conversation.