### PR TITLE
support token auth for the chatto-cli REST channel client

### DIFF
--- a/bot/client.go
+++ b/bot/client.go
@@ -92,8 +92,8 @@ func (c *Client) Submit(question *query.Question) ([]query.Answer, error) {
 	}()
 
 	answers := []query.Answer{}
-	if err = json.NewDecoder(resp.Body).Decode(&answers); err != nil {
-		return nil, err
+	if decodeErr := json.NewDecoder(resp.Body).Decode(&answers); decodeErr != nil {
+		return nil, decodeErr
 	}
 
 	return answers, nil

--- a/cmd/chatto-cli/main.go
+++ b/cmd/chatto-cli/main.go
@@ -10,8 +10,9 @@ import (
 )
 
 func main() {
-	url := flag.String("url", "http://localhost", "Specify url to use.")
-	port := flag.Int("port", 4770, "Specify port to use.")
+	url := flag.String("url", "http://localhost", "Specify REST channel url to use.")
+	port := flag.Int("port", 4770, "Specify REST channel port to use.")
+	token := flag.String("token", "", "Specify REST channel auth token to use.")
 	debug := flag.Bool("debug", false, "Enable debug logging.")
 	vers := flag.Bool("version", false, "Display version.")
 	flag.Parse()
@@ -23,7 +24,7 @@ func main() {
 
 	logger.SetLogger(*debug)
 
-	client := bot.NewClient(*url, *port)
+	client := bot.NewClient(*url, *port, *token)
 
 	client.CLI()
 }


### PR DESCRIPTION
This change adds support for token auth in the `chatto-cli` REST channel client.