### PR TITLE
use consistent name for bot

### DIFF
--- a/bot/client.go
+++ b/bot/client.go
@@ -14,7 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Client allows you to chat with botto through the REST channel
+// Client allows you to chat with chatto through the REST channel
 // Great for testing or integrating with your own tools
 type Client struct {
 	URL   string
@@ -22,7 +22,7 @@ type Client struct {
 	http  *retryablehttp.Client
 }
 
-// NewClient instantiates a new botto client
+// NewClient instantiates a new chatto client
 func NewClient(url string, port int, token string) *Client {
 	client := &Client{
 		URL:   fmt.Sprintf("%s:%d/channels/rest", url, port),
@@ -62,7 +62,7 @@ func (c *Client) CLI() {
 	}
 }
 
-// Submit a question to botto bot and get an answer
+// Submit a question to chatto bot and get an answer
 func (c *Client) Submit(question *query.Question) ([]query.Answer, error) {
 	questionJSON, err := json.Marshal(question)
 	if err != nil {

--- a/bot/server.go
+++ b/bot/server.go
@@ -9,12 +9,12 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Server runs botto bot
+// Server runs chatto bot
 type Server struct {
 	bot *bot.Bot
 }
 
-// NewServer for running botto bot
+// NewServer for running chatto bot
 func NewServer(path string, port int) *Server {
 	botConfig, err := bot.LoadConfig(path, port)
 	if err != nil {
@@ -56,7 +56,7 @@ func (s *Server) SlackHandler(w http.ResponseWriter, r *http.Request) {
 	s.bot.ChannelHandler(w, r, s.bot.Channels.Slack)
 }
 
-// Run botto bot server
+// Run chatto bot server
 func (s *Server) Run() {
 	s.bot.Run()
 }

--- a/internal/bot/config.go
+++ b/internal/bot/config.go
@@ -111,7 +111,7 @@ func loadName(name string) string {
 		return name
 	}
 
-	return "botto"
+	return "chatto"
 }
 
 // New initializes and returns a new Bot


### PR DESCRIPTION
I am not sure if you noticed but in some places, it's referred to as `botto` and not `chatto`. Not sure if this is on purpose or not. 