### PR TITLE
feat: detect commands and states from transitions

### DIFF
--- a/examples/00_test/fsm.yml
+++ b/examples/00_test/fsm.yml
@@ -1,31 +1,22 @@
-states:
-  - "off"
-  - "on"
-
-commands:
-  - "turn_on"
-  - "turn_off"
-  - "hello_universe"
-
 transitions:
   - from:
-      - "off"
+      - "initial"
     into: "on"
     command: "turn_on"
-    message: 
+    answers:
       - text: "Turning on."
 
   - from:
       - "on"
-    into: "off"
+    into: "initial"
     command: "turn_off"
-    message:
+    answers:
       - text: "Turning off."
       - text: "❌"
 
   - from:
       - "any"
-    into: "off"
+    into: "initial"
     command: "hello_universe"
     extension: "any"
 

--- a/examples/01_moodbot/fsm.yml
+++ b/examples/01_moodbot/fsm.yml
@@ -1,17 +1,3 @@
-states:
-  - "initial"
-  - "ask_mood"
-  - "say_good"
-  - "say_bad"
-  - "say_bye"
-
-commands:
-  - "greet"
-  - "good"
-  - "bad"
-  - "yes"
-  - "no"
-
 transitions:
   - from:
       - initial

--- a/examples/02_misc/fsm.yml
+++ b/examples/02_misc/fsm.yml
@@ -1,14 +1,3 @@
-states:
-  - "initial"
-  - "ask_location"
-
-commands:
-  - "hi"
-  - "weather"
-  - "joke"
-  - "misc"
-  - "quote"
-
 transitions:
   - from:
       - "initial"

--- a/examples/03_pokemon/fsm.yml
+++ b/examples/03_pokemon/fsm.yml
@@ -1,12 +1,3 @@
-states:
-  - "initial"
-  - "search_pokemon"
-
-commands:
-  - "greet"
-  - "search_pokemon"
-  - "faq"
-
 transitions:
   - from:
       - initial
@@ -43,4 +34,4 @@ transitions:
 defaults:
   unknown: "Unknown command, try again please."
   unsure: "Not sure I understood, try again please."
-  error: "I'm sorry, an error ocurred."
+  error: "I'm sorry, an error occurred."

--- a/examples/04_trivia/fsm.yml
+++ b/examples/04_trivia/fsm.yml
@@ -1,13 +1,3 @@
-states:
-  - initial
-  - question_1
-  - question_2
-  - question_3
-
-commands:
-  - start
-  - end
-
 transitions:
   - from:
       - initial

--- a/examples/05_simple/fsm.yml
+++ b/examples/05_simple/fsm.yml
@@ -1,14 +1,6 @@
-states:
-  - "off"
-  - "on"
-
-commands:
-  - "turn_on"
-  - "turn_off"
-
 transitions:
   - from:
-      - "off"
+      - "initial"
     into: "on"
     command: "turn_on"
     answers: 
@@ -16,7 +8,7 @@ transitions:
 
   - from:
       - "on"
-    into: "off"
+    into: "initial"
     command: "turn_off"
     answers:
       - text: "Turning off."

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -60,8 +60,8 @@ func NewStateTable(transitions []Transition) StateTable {
 
 	stateTable := make(StateTable, len(transitions)+stateTableDefaultSize)
 
-	stateTable["any"] = -1    // Add state "any" ID
-	stateTable["initial"] = 0 // Add state "initial" ID
+	stateTable["any"] = StateAny         // Add state "any" ID
+	stateTable["initial"] = StateInitial // Add state "initial" ID
 
 	// Starting state ID
 	stateID := 1

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -55,14 +55,31 @@ type Answer struct {
 type StateTable map[string]int
 
 // NewStateTable initializes a new StateTable
-func NewStateTable(states []string) StateTable {
-	stateTable := make(StateTable, len(states)+1)
+func NewStateTable(transitions []Transition) StateTable {
+	stateTableDefaultSize := 2
 
-	for id, state := range states {
-		stateTable[state] = id
+	stateTable := make(StateTable, len(transitions)+stateTableDefaultSize)
+
+	stateTable["any"] = -1    // Add state "any" ID
+	stateTable["initial"] = 0 // Add state "initial" ID
+
+	// Starting state ID
+	stateID := 1
+
+	for n := range transitions {
+		state := strings.TrimSpace(transitions[n].Into)
+
+		// Do not add duplicate states
+		if _, ok := stateTable[state]; ok {
+			continue
+		}
+
+		// Set state name to id mapping
+		stateTable[state] = stateID
+
+		// Increment state ID
+		stateID++
 	}
-
-	stateTable["any"] = StateAny
 
 	return stateTable
 }
@@ -124,7 +141,6 @@ func NewSlotTable(transitions []Transition, stateTable StateTable) SlotTable {
 // BaseDomain contains the data required for a minimally functioning FSM
 type BaseDomain struct {
 	StateTable      StateTable `json:"state_table"`
-	CommandList     []string   `json:"command_list"`
 	DefaultMessages Defaults   `json:"default_messages"`
 }
 
@@ -137,11 +153,10 @@ type Domain struct {
 }
 
 // NewDomain initializes a new Domain
-func NewDomain(commands, states []string, transitions []Transition, defaults Defaults) *Domain {
+func NewDomain(transitions []Transition, defaults Defaults) *Domain {
 	fsmDomain := &Domain{}
-	fsmDomain.CommandList = commands
 	fsmDomain.DefaultMessages = defaults
-	fsmDomain.StateTable = NewStateTable(states)
+	fsmDomain.StateTable = NewStateTable(transitions)
 	fsmDomain.TransitionTable = NewTransitionTable(transitions, fsmDomain.StateTable)
 	fsmDomain.SlotTable = NewSlotTable(transitions, fsmDomain.StateTable)
 

--- a/fsm/fsm_test.go
+++ b/fsm/fsm_test.go
@@ -10,14 +10,10 @@ import (
 
 var (
 	// Hello
-	helloCommands  = []string{"hey_friend"}
-	helloStates    = []string{"hello"}
 	helloFunctions = []fsm.Transition{
 		{
-			// Transition: fsm.Transition{
-			From: []string{"any"},
-			Into: "hello",
-			// },
+			From:    []string{"any"},
+			Into:    "hello",
 			Command: "hey_friend",
 			Answers: []fsm.Answer{{
 				Text: "Hey friend!",
@@ -26,34 +22,26 @@ var (
 	}
 
 	// Pokemon test
-	pokemonCommands  = []string{"initial", "search_pokemon"}
-	pokemonStates    = []string{"greet", "search_pokemon"}
 	pokemonFunctions = []fsm.Transition{
 		{
-			// Transition: fsm.Transition{
-			From: []string{"initial"},
-			Into: "search_pokemon",
-			// },
+			From:    []string{"initial"},
+			Into:    "search_pokemon",
 			Command: "search_pokemon",
 			Answers: []fsm.Answer{{
 				Text: "What is the Pokémon's name or number?",
 			}},
 		},
 		{
-			// Transition: fsm.Transition{
-			From: []string{"initial"},
-			Into: "search_pokemon",
-			// },
+			From:    []string{"initial"},
+			Into:    "search_pokemon",
 			Command: "greet",
 			Answers: []fsm.Answer{{
 				Text: "What is the Pokémon's name or number?",
 			}},
 		},
 		{
-			// Transition: fsm.Transition{
-			From: []string{"search_pokemon"},
-			Into: "initial",
-			// },
+			From:      []string{"search_pokemon"},
+			Into:      "initial",
 			Command:   "any",
 			Extension: "search_pokemon",
 			Slot: fsm.Slot{
@@ -64,14 +52,10 @@ var (
 	}
 
 	// On off test
-	onOffCommands  = []string{"turn_on", "turn_off"}
-	onOffStates    = []string{"off", "on"}
 	onOffFunctions = []fsm.Transition{
 		{
-			// Transition: fsm.Transition{
-			From: []string{"off"},
-			Into: "on",
-			// },
+			From:    []string{"initial"},
+			Into:    "on",
 			Command: "turn_on",
 			Answers: []fsm.Answer{{
 				Text: "Turning on.",
@@ -82,10 +66,8 @@ var (
 			},
 		},
 		{
-			// Transition: fsm.Transition{
-			From: []string{"on"},
-			Into: "off",
-			// },
+			From:    []string{"on"},
+			Into:    "initial",
 			Command: "turn_off",
 			Answers: []fsm.Answer{
 				{
@@ -138,7 +120,7 @@ func TestFSM_ExecuteCmd(t *testing.T) {
 			args: args{
 				command:   "ruhrow",
 				txt:       "blah blah blah",
-				fsmDomain: fsm.NewDomain(onOffCommands, onOffStates, onOffFunctions, defaultResponses),
+				fsmDomain: fsm.NewDomain(onOffFunctions, defaultResponses),
 			},
 			wantAnswers:   nil,
 			wantExtension: "",
@@ -155,7 +137,7 @@ func TestFSM_ExecuteCmd(t *testing.T) {
 			args: args{
 				command:   "",
 				txt:       "blah blah blah",
-				fsmDomain: fsm.NewDomain(onOffCommands, onOffStates, onOffFunctions, defaultResponses),
+				fsmDomain: fsm.NewDomain(onOffFunctions, defaultResponses),
 			},
 			wantAnswers:   nil,
 			wantExtension: "",
@@ -172,7 +154,7 @@ func TestFSM_ExecuteCmd(t *testing.T) {
 			args: args{
 				command:   "hey_friend",
 				txt:       "hey there",
-				fsmDomain: fsm.NewDomain(helloCommands, helloStates, helloFunctions, defaultResponses),
+				fsmDomain: fsm.NewDomain(helloFunctions, defaultResponses),
 			},
 			wantAnswers: []query.Answer{{
 				Text: "Hey friend!",
@@ -191,7 +173,7 @@ func TestFSM_ExecuteCmd(t *testing.T) {
 			args: args{
 				command:   "any",
 				txt:       "pikachu",
-				fsmDomain: fsm.NewDomain(pokemonCommands, pokemonStates, pokemonFunctions, defaultResponses),
+				fsmDomain: fsm.NewDomain(pokemonFunctions, defaultResponses),
 			},
 			wantAnswers:   nil,
 			wantExtension: "search_pokemon",
@@ -208,7 +190,7 @@ func TestFSM_ExecuteCmd(t *testing.T) {
 			args: args{
 				command:   "turn_on",
 				txt:       "turn it on",
-				fsmDomain: fsm.NewDomain(onOffCommands, onOffStates, onOffFunctions, defaultResponses),
+				fsmDomain: fsm.NewDomain(onOffFunctions, defaultResponses),
 			},
 			wantAnswers: []query.Answer{{
 				Text: "Turning on.",
@@ -227,7 +209,7 @@ func TestFSM_ExecuteCmd(t *testing.T) {
 			args: args{
 				command:   "turn_off",
 				txt:       "turn it off",
-				fsmDomain: fsm.NewDomain(onOffCommands, onOffStates, onOffFunctions, defaultResponses),
+				fsmDomain: fsm.NewDomain(onOffFunctions, defaultResponses),
 			},
 			wantAnswers: []query.Answer{
 				{

--- a/internal/channels/rest/rest_test.go
+++ b/internal/channels/rest/rest_test.go
@@ -52,6 +52,7 @@ func TestChannel_ReceiveMessage(t *testing.T) {
 		})
 	}
 }
+
 func TestChannel_ValidateCallback(t *testing.T) {
 	setBearerToken := func(r *http.Request, t string) *http.Request {
 		r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", t))

--- a/internal/fsm/config.go
+++ b/internal/fsm/config.go
@@ -9,10 +9,8 @@ import (
 // Config contains the states, commands, functions and
 // default messages of the FSM
 type Config struct {
-	States      []string         `yaml:"states"`
-	Commands    []string         `yaml:"commands"`
-	Transitions []fsm.Transition `yaml:"transitions"`
-	Defaults    fsm.Defaults     `yaml:"defaults"`
+	Transitions []fsm.Transition `yaml:"transitions" mapstructure:"transitions"`
+	Defaults    fsm.Defaults     `yaml:"defaults" mapstructure:"defaults"`
 }
 
 // LoadConfig loads the FSM configuration from yaml
@@ -38,7 +36,7 @@ func LoadConfig(path string) (*Config, error) {
 
 // NewDomainFromConfig initializes a FSM Domain from the FSM Config
 func NewDomainFromConfig(fsmConfig *Config) *fsm.Domain {
-	fsmDomain := fsm.NewDomain(fsmConfig.Commands, fsmConfig.States, fsmConfig.Transitions, fsmConfig.Defaults)
+	fsmDomain := fsm.NewDomain(fsmConfig.Transitions, fsmConfig.Defaults)
 
 	log.Info("Loaded states:")
 	for stateName, stateID := range fsmDomain.StateTable {

--- a/internal/fsm/config_test.go
+++ b/internal/fsm/config_test.go
@@ -23,24 +23,18 @@ func TestLoadConfig(t *testing.T) {
 			name: "test loading a valid path",
 			args: args{path: "../" + testutils.Examples05SimplePath},
 			want: &fsmint.Config{
-				States:   []string{"off", "on"},
-				Commands: []string{"turn_on", "turn_off"},
 				Transitions: []fsm.Transition{
 					{
-						// Transition: fsm.Transition{
-						From: []string{"off"},
-						Into: "on",
-						// },
+						From:    []string{"initial"},
+						Into:    "on",
 						Command: "turn_on",
 						Answers: []fsm.Answer{{
 							Text: "Turning on.",
 						}},
 					},
 					{
-						// Transition: fsm.Transition{
-						From: []string{"on"},
-						Into: "off",
-						// },
+						From:    []string{"on"},
+						Into:    "initial",
 						Command: "turn_off",
 						Answers: []fsm.Answer{
 							{


### PR DESCRIPTION
This feature removes the need to define the commands and states in the FSM config. The FSM will now automatically determine these values from transitions. To further simplify things I the first state is now 'initial' always. This should clarify when writing FSM transitions that everyone knows what the 'initial' state name is. Similar to how nice the 'any' state is.

Resolves https://github.com/jaimeteb/chatto/issues/36