### PR TITLE
Read all states / Use `time.Duration` for time configurations

### DIFF
--- a/examples/04_trivia/bot.yml
+++ b/examples/04_trivia/bot.yml
@@ -11,7 +11,7 @@ store:
   type: REDIS
   host: localhost
   password: pass
-  ttl: 3600
+  ttl: 1h
   # type: CACHE
-  # ttl: 30
-  # purge: 60
+  # ttl: 30s
+  # purge: 60s

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -73,19 +73,26 @@ func NewStateTable(transitions []Transition) StateTable {
 	// Starting state ID
 	stateID := 1
 
-	for n := range transitions {
-		state := strings.TrimSpace(transitions[n].Into)
-
+	addState := func(state string) {
 		// Do not add duplicate states
 		if _, ok := stateTable[state]; ok {
-			continue
+			return
 		}
-
 		// Set state name to id mapping
 		stateTable[state] = stateID
-
 		// Increment state ID
 		stateID++
+	}
+
+	for n := range transitions {
+		// Register "from" states
+		for _, fr := range transitions[n].From {
+			state := strings.TrimSpace(fr)
+			addState(state)
+		}
+		// Register "into" state
+		state := strings.TrimSpace(transitions[n].Into)
+		addState(state)
 	}
 
 	return stateTable

--- a/internal/bot/config.go
+++ b/internal/bot/config.go
@@ -90,6 +90,8 @@ func LoadConfig(path string, port int) (*Config, error) {
 	config.SetDefault("conversation.existing.reply_unsure", true)
 	config.SetDefault("conversation.existing.reply_unknown", true)
 	config.SetDefault("conversation.existing.reply_error", true)
+	config.SetDefault("store.ttl", "-1s")
+	config.SetDefault("store.purge", "-1s")
 
 	if err := config.ReadInConfig(); err != nil {
 		switch err.(type) {

--- a/internal/channels/slack/slack.go
+++ b/internal/channels/slack/slack.go
@@ -25,9 +25,9 @@ type MessageIn struct {
 
 // Config contains the Slack token
 type Config struct {
-	Token    string `mapstructure:"token"`
-	AppToken string `mapstructure:"app_token"`
-	Delay    int    `mapstructure:"delay"`
+	Token    string        `mapstructure:"token"`
+	AppToken string        `mapstructure:"app_token"`
+	Delay    time.Duration `mapstructure:"delay"`
 }
 
 // Client is the Slack client interface
@@ -46,7 +46,7 @@ type Channel struct {
 	Client             Client
 	SocketClient       SocketClient
 	SocketClientEvents chan socketmode.Event
-	delay              int
+	delay              time.Duration
 }
 
 // New returns an initialized slack client
@@ -59,7 +59,7 @@ func New(config Config) *Channel {
 
 	slackClient := slack.New(config.Token, slackOpts...)
 
-	client := &Channel{Client: slackClient}
+	client := &Channel{Client: slackClient, delay: config.Delay}
 
 	if config.AppToken != "" {
 		socketclient := socketmode.New(slackClient)
@@ -103,7 +103,7 @@ func (c *Channel) SendMessage(response *messages.Response) error {
 		}
 		log.Debugf("Slack response: %s", ret)
 
-		time.Sleep(time.Duration(c.delay) * time.Second)
+		time.Sleep(c.delay)
 	}
 
 	return nil

--- a/internal/channels/telegram/telegram.go
+++ b/internal/channels/telegram/telegram.go
@@ -38,8 +38,8 @@ type MessageInInnerFrom struct {
 
 // Config models Telegram configuration
 type Config struct {
-	BotKey string `mapstructure:"bot_key"`
-	Delay  int    `mapstructure:"delay"`
+	BotKey string        `mapstructure:"bot_key"`
+	Delay  time.Duration `mapstructure:"delay"`
 }
 
 // Client is the Telegram client interface
@@ -50,7 +50,7 @@ type Client interface {
 // Channel contains a Telegram client
 type Channel struct {
 	Client Client
-	delay  int
+	delay  time.Duration
 }
 
 // New returns an initialized Telegram client
@@ -59,7 +59,7 @@ func New(config Config) *Channel {
 
 	log.Infof("Added Telegram client: %v", client.GetMe().ID)
 
-	return &Channel{Client: client}
+	return &Channel{Client: client, delay: config.Delay}
 }
 
 // SendMessage for Telegram
@@ -85,7 +85,7 @@ func (c *Channel) SendMessage(response *messages.Response) error {
 		c.Client.Call(method, respValues, apiResp)
 		log.Debugf("Telegram response: %+v", apiResp)
 
-		time.Sleep(time.Duration(c.delay) * time.Second)
+		time.Sleep(c.delay)
 	}
 
 	return nil

--- a/internal/channels/twilio/twilio.go
+++ b/internal/channels/twilio/twilio.go
@@ -37,10 +37,10 @@ type MessageIn struct {
 
 // Config models Twilio configuration
 type Config struct {
-	AccountSid string `mapstructure:"account_sid"`
-	AuthToken  string `mapstructure:"auth_token"`
-	Number     string `mapstructure:"number"`
-	Delay      int    `mapstructure:"delay"`
+	AccountSid string        `mapstructure:"account_sid"`
+	AuthToken  string        `mapstructure:"auth_token"`
+	Number     string        `mapstructure:"number"`
+	Delay      time.Duration `mapstructure:"delay"`
 }
 
 // Client is the twilio client interface
@@ -53,7 +53,7 @@ type Channel struct {
 	Client Client
 	Number string
 	token  string
-	delay  int
+	delay  time.Duration
 }
 
 // New returns an initialized telegram client
@@ -62,7 +62,7 @@ func New(config Config) *Channel {
 
 	log.Infof("Added Twilio client: %v", client.AccountSid)
 
-	return &Channel{Client: client.Messages, Number: config.Number, token: config.AuthToken}
+	return &Channel{Client: client.Messages, Number: config.Number, token: config.AuthToken, delay: config.Delay}
 }
 
 // SendMessage for Twilio
@@ -82,7 +82,7 @@ func (c *Channel) SendMessage(response *messages.Response) error {
 		}
 		log.Debugf("Twilio response: %+v", apiResp)
 
-		time.Sleep(time.Duration(c.delay) * time.Second)
+		time.Sleep(c.delay)
 	}
 
 	return nil

--- a/internal/fsm/store/cache/cache.go
+++ b/internal/fsm/store/cache/cache.go
@@ -1,8 +1,6 @@
 package cache
 
 import (
-	"time"
-
 	"github.com/jaimeteb/chatto/fsm"
 	"github.com/jaimeteb/chatto/internal/fsm/store/config"
 	"github.com/patrickmn/go-cache"
@@ -19,8 +17,8 @@ func NewStore(cfg *config.StoreConfig) *Store {
 	log.Infof("* Purge:  %v", cfg.Purge)
 	return &Store{
 		C: cache.New(
-			time.Duration(cfg.TTL)*time.Second,
-			time.Duration(cfg.Purge)*time.Second,
+			cfg.TTL,
+			cfg.Purge,
 		),
 	}
 }

--- a/internal/fsm/store/config/config.go
+++ b/internal/fsm/store/config/config.go
@@ -1,14 +1,16 @@
 package config
 
+import "time"
+
 // StoreConfig struct models a Store configuration in bot.yml
 type StoreConfig struct {
-	Type     string `mapstructure:"type"`
-	TTL      int    `mapstructure:"ttl"`
-	Purge    int    `mapstructure:"purge"`
-	Host     string `mapstructure:"host"`
-	Port     string `mapstructure:"port"`
-	User     string `mapstructure:"user"`
-	Password string `mapstructure:"password"`
-	Database string `mapstructure:"database"`
-	RDBMS    string `mapstructure:"rdbms"`
+	Type     string        `mapstructure:"type"`
+	TTL      time.Duration `mapstructure:"ttl"`
+	Purge    time.Duration `mapstructure:"purge"`
+	Host     string        `mapstructure:"host"`
+	Port     string        `mapstructure:"port"`
+	User     string        `mapstructure:"user"`
+	Password string        `mapstructure:"password"`
+	Database string        `mapstructure:"database"`
+	RDBMS    string        `mapstructure:"rdbms"`
 }

--- a/internal/fsm/store/redis/redis.go
+++ b/internal/fsm/store/redis/redis.go
@@ -17,7 +17,7 @@ var ctx = context.Background()
 // Store struct models an FSM sotred on Redis
 type Store struct {
 	R   Client
-	TTL int
+	TTL time.Duration
 }
 
 type Client interface {
@@ -79,7 +79,7 @@ func (s *Store) Get(user string) *fsm.FSM {
 
 // Set method for Store
 func (s *Store) Set(user string, m *fsm.FSM) {
-	if err := s.R.Set(ctx, user+":state", m.State, time.Duration(s.TTL)*time.Second).Err(); err != nil {
+	if err := s.R.Set(ctx, user+":state", m.State, s.TTL).Err(); err != nil {
 		log.Error("Error setting state:", err)
 	}
 	if len(m.Slots) > 0 {
@@ -91,7 +91,7 @@ func (s *Store) Set(user string, m *fsm.FSM) {
 		if err := s.R.HSet(ctx, user+":slots", kvs).Err(); err != nil {
 			log.Error("Error setting slots:", err)
 		}
-		if err := s.R.Expire(ctx, user+":slots", time.Duration(s.TTL)*time.Second).Err(); err != nil {
+		if err := s.R.Expire(ctx, user+":slots", s.TTL).Err(); err != nil {
 			log.Error("Error expiring slots:", err)
 		}
 	}

--- a/internal/fsm/store/sql/sql.go
+++ b/internal/fsm/store/sql/sql.go
@@ -166,13 +166,13 @@ func (s *Store) Set(user string, m *fsm.FSM) {
 	}
 }
 
-func (s *Store) runPurge(ttl, purge int) {
+func (s *Store) runPurge(ttl, purge time.Duration) {
 	if ttl > 0 && purge > 0 {
 		go func() {
-			ticker := time.NewTicker(time.Duration(purge) * time.Second)
+			ticker := time.NewTicker(purge)
 			for {
 				for range ticker.C {
-					expired := time.Now().Add(-time.Duration(ttl) * time.Second)
+					expired := time.Now().Add(-ttl)
 					s.DB.Where("updated_at < ?", expired).Delete(&FSMORM{})
 				}
 			}

--- a/internal/fsm/store/store.go
+++ b/internal/fsm/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"strings"
+	"time"
 
 	"github.com/jaimeteb/chatto/fsm"
 	"github.com/jaimeteb/chatto/internal/fsm/store/cache"
@@ -10,6 +11,8 @@ import (
 	"github.com/jaimeteb/chatto/internal/fsm/store/sql"
 	log "github.com/sirupsen/logrus"
 )
+
+var defaultDuration = -1 * time.Second
 
 // Store interface for FSM Store modes
 type Store interface {
@@ -22,15 +25,8 @@ type Store interface {
 func New(cfg *config.StoreConfig) Store {
 	var machines Store
 
-	if cfg.TTL == 0 {
-		cfg.TTL = -1
-	}
-	if cfg.Purge == 0 {
-		if cfg.TTL != 0 {
-			cfg.Purge = cfg.TTL
-		} else {
-			cfg.Purge = -1
-		}
+	if cfg.Purge == defaultDuration && cfg.TTL != defaultDuration {
+		cfg.Purge = cfg.TTL
 	}
 
 	switch strings.ToLower(cfg.Type) {


### PR DESCRIPTION
- Register states from transitions' `from` and `into` states, for cases where a state can only be reached via extensions.
- Use `time.Duration` for:
    - Store `TTL` and `Purge` times.
    - Channel delays.

    Now these times can be specified as:
    ```yaml
    # milliseconds
    delay: 300ms
    # seconds
    delay: 5s
    # minutes
    delay: 1m
    # etc...
    ```